### PR TITLE
fixed tree drawing and text positioning

### DIFF
--- a/frontend/src/tree/node.ts
+++ b/frontend/src/tree/node.ts
@@ -2,15 +2,15 @@ export class Node_ {
   private children: [Node_, Node_];
 
   constructor(private id: number,
-              private parent_: number,
+              private parent_: Node_,
               private pc: string,
               private ifPC?: string,
               private elsePC?: string) {
     if (ifPC && elsePC) {
       // Then this is an actual node and will have
       // two virtual nodes as children
-      this.children = [new Node_((-2) * id - 1, id, ifPC), 
-                       new Node_((-2) * id - 2, id, elsePC)];
+      this.children = [new Node_((-2) * id - 1, this, ifPC), 
+                       new Node_((-2) * id - 2, this, elsePC)];
     } else {
       // Then this is a virtual node and it has
       // no children
@@ -27,6 +27,16 @@ export class Node_ {
     const [leftNode, _] = this.children;
     this.children = [leftNode, rightNode];
   };
+
+  public isLeft() {
+    if(!this.parent_) return false;
+    return this == this.getParent().getLeft();
+  }
+
+  public isRight() {
+    if(!this.parent_) return false;
+    return this == this.getParent().getRight();
+  }
 
   public getLeft() {
     const [left, _] = this.children;

--- a/frontend/src/tree/tree.component.ts
+++ b/frontend/src/tree/tree.component.ts
@@ -71,7 +71,7 @@ export class TreeComponent implements OnInit, OnChanges {
         console.log(clickedID);
         var currID = this.currNode.getID();
         console.log(currID);
-        if(clickedID < 0 && d.getParent() == currID) {
+        if(clickedID < 0 && d.getParent().getID() == currID) {
           // you are in the currNode's virtual node
           var leftID = -2 * currID - 1;
           var rightID = leftID - 1;
@@ -121,6 +121,7 @@ export class TreeComponent implements OnInit, OnChanges {
     node.exit().remove();
 
     // Update the links…
+    svg.selectAll('g.link').remove();
     var link = svg.selectAll('g.link').data(links);
 
     // Enter any new links at the parent's previous position.
@@ -133,9 +134,9 @@ export class TreeComponent implements OnInit, OnChanges {
       .attr('d', diagonal);
 
     link.selectAll('text')
-    .attr('x', d => 0.5*d.source.x + 0.5*d.target.x - 15)
+    .attr('x', d => 0.5*d.source.x + 0.5*d.target.x + ((d.target.isRight())? 20: -20))
     .attr('y', d => 0.5*d.source.y + 0.5*d.target.y)
-    .attr('text-anchor', d => d.children? 'end' : 'start')
+    .attr('text-anchor', d => (d.target.isRight())? 'start' : 'end')
     .text((d:any) => d.target.pc);
 
     link.attr('class', 'link');

--- a/frontend/src/tree/tree.service.ts
+++ b/frontend/src/tree/tree.service.ts
@@ -32,7 +32,7 @@ export class TreeService {
   addNewLeft(currNode, node) {
     console.log("Adding new left");
     node = new Node_(node.id,
-                    currNode.getID(),
+                    currNode,
                     currNode.getIfPC(),
                     node.IfPC,
                     node.ElsePC);
@@ -45,7 +45,7 @@ export class TreeService {
   addNewRight(currNode, node) {
     console.log("Adding new right");
     node = new Node_(node.id,
-                    currNode.getID(),
+                    currNode,
                     currNode.getElsePC(),
                     node.IfPC,
                     node.ElsePC);


### PR DESCRIPTION
Note that I have changed the structure of `Node_` too. Instead of storing the id of the parent, store the Node_ itself. See `node.ts` line 5. 

Added 2 functions, `isLeft()` and `isRight()` to `Node_`, which determines if a node is a left/right child of its parent. Returns false if it is root.

Also fix the tree drawing problems.